### PR TITLE
do pass groups individually to auth backend

### DIFF
--- a/syntax/table.php
+++ b/syntax/table.php
@@ -113,22 +113,24 @@ class syntax_plugin_groupmatrix_table extends DokuWiki_Syntax_Plugin
         $rows = [];
         foreach ($groups as $group) {
             $users = $auth->retrieveUsers(0, -1, ['grps' => $group]);
-            foreach ($users as $user) {
-                if (!isset($rows[$user['user']])) {
+            foreach ($users as $user => $userinfo) {
+                // not all backends return the user in the info array, fix that here
+                $userinfo['user'] = $user;
+                if (!isset($rows[$user])) {
                     // prepare row of attributes + groups
-                    $rows[$user['user']] = array_merge(
+                    $rows[$user] = array_merge(
                         array_merge(
                             // ensure all atributes are set, even when missing in $user
                             array_fill_keys($attributes, ''),
                             // extract the wanted attributes from $user
-                            array_intersect_key($user, array_flip($attributes))
+                            array_intersect_key($userinfo, array_flip($attributes))
                         ),
                         // add all groups to the row
                         array_fill_keys($groups, '')
                     );
                 }
                 // add group membership
-                $rows[$user['user']][$group] = self::MARK;
+                $rows[$user][$group] = self::MARK;
             }
         }
 

--- a/syntax/table.php
+++ b/syntax/table.php
@@ -10,7 +10,6 @@ class syntax_plugin_groupmatrix_table extends DokuWiki_Syntax_Plugin
 {
     const MARK = '✓';
 
-
     /**
      * @return string Syntax mode type
      */
@@ -82,13 +81,10 @@ class syntax_plugin_groupmatrix_table extends DokuWiki_Syntax_Plugin
         $data['attributes'] = $this->trimexplode(',', $cfg['attributes']);
         $data['groups'] = $this->trimexplode(',', $cfg['groups']);
         $titles = $this->trimexplode(',', $cfg['titles']);
-        if(empty($data['attributes'])) $data['attributes'] = ['user'];
-
+        if (empty($data['attributes'])) $data['attributes'] = ['user'];
 
         $groupHeaders = $titles ? array_replace($data['groups'], $titles) : $data['groups'];
         $data['headers'] = array_merge($data['attributes'], $groupHeaders);
-
-
 
         return $data;
     }
@@ -114,30 +110,30 @@ class syntax_plugin_groupmatrix_table extends DokuWiki_Syntax_Plugin
         $groups = $data['groups'];
         $attributes = $data['attributes'];
 
-        $users = $auth->retrieveUsers(0,
-            -1,
-            ['grps' => implode('|', $groups)]
-        );
-
-        // no results from auth backend
-        if (empty($users)) {
-            $rows = [];
-        } else {
-            // convert user data into matrix row: attributes and group membership flags
-            $rows = array_map(function ($user, $username) use ($groups, $attributes) {
-                // special handling of 'user': always use the wiki username from array key
-                $user['user'] = $username;
-
-                foreach ($attributes as $attribute) {
-                    $row[$attribute] = $user[$attribute] ?: '';
+        $rows = [];
+        foreach ($groups as $group) {
+            $users = $auth->retrieveUsers(0, -1, ['grps' => $group]);
+            foreach ($users as $user) {
+                if (!isset($rows[$user['user']])) {
+                    // prepare row of attributes + groups
+                    $rows[$user['user']] = array_merge(
+                        array_merge(
+                            // ensure all atributes are set, even when missing in $user
+                            array_fill_keys($attributes, ''),
+                            // extract the wanted attributes from $user
+                            array_intersect_key($user, array_flip($attributes))
+                        ),
+                        // add all groups to the row
+                        array_fill_keys($groups, '')
+                    );
                 }
-                foreach ($groups as $group) {
-                    $row['memberof'][$group] = in_array($group, $user['grps']) ? self::MARK : '';
-                }
-
-                return $row;
-            }, $users, array_keys($users));
+                // add group membership
+                $rows[$user['user']][$group] = self::MARK;
+            }
         }
+
+        // sort by user name
+        ksort($rows);
 
         $renderer->doc .= $this->renderTable($data['headers'], $rows);
         return true;

--- a/syntax/table.php
+++ b/syntax/table.php
@@ -125,12 +125,12 @@ class syntax_plugin_groupmatrix_table extends DokuWiki_Syntax_Plugin
                             // extract the wanted attributes from $user
                             array_intersect_key($userinfo, array_flip($attributes))
                         ),
-                        // add all groups to the row
-                        array_fill_keys($groups, '')
+                        // add all groups to the row as sub array
+                        ['group__members' => array_fill_keys($groups, '')]
                     );
                 }
                 // add group membership
-                $rows[$user][$group] = self::MARK;
+                $rows[$user]['group__members'][$group] = self::MARK;
             }
         }
 


### PR DESCRIPTION
As discussed in https://github.com/splitbrain/dokuwiki/issues/3028, what
can be passed as a $filter to retrieveUsers() is ill defined right now.
Assuming that we can pass a | to fetch users from two different groups
is bound to fail with various backends.

This patch will ask for members of all given groups separately and merge
them in code. By passing a simple string (not a pattern) this should be
the most compatible implementation for the current situation.

It might be a good idea to allow an array to be passed in the grps
filter (or even in all filters?) to signal that you want to match
multiple groups. This should be discussed in the ticket above.